### PR TITLE
Fix for #22 use correct params for str_contains

### DIFF
--- a/src/Parsers/PingParserForLinux.php
+++ b/src/Parsers/PingParserForLinux.php
@@ -95,7 +95,7 @@ final class PingParserForLinux extends PingParser
         $sequence = [];
 
         foreach ($ping as $row) {
-            if (str_contains('Unreachable', $row)) {
+            if (str_contains($row, 'Unreachable')) {
                 $data = explode(': ', str_replace(' ms', '', $row));
                 $items = explode(' ', $data[1]);
 


### PR DESCRIPTION
```str_contains(string $haystack, string $needle) ```

Was mixed the wrong way round