### PR TITLE
Fixes UnknownOSException on macOS

### DIFF
--- a/src/System.php
+++ b/src/System.php
@@ -34,7 +34,7 @@ class System
      */
     public static function isOSX(): bool
     {
-        return PHP_OS_FAMILY === 'OSX';
+        return PHP_OS_FAMILY === 'Darwin';
     }
 
     /**


### PR DESCRIPTION
Throws an UnknownOSException on macOS:

```
Acamposm\Ping\Exceptions\UnknownOSException 

  Unknown OS

  at /Users/ahoiroman/Entwicklung/Laravel/exampleli/vendor/acamposm/ping/src/PingCommandBuilder.php:303
    299▕         if (System::isWindows()) {
    300▕             return $this->getWindowsCommand();
    301▕         }
    302▕ 
  ➜ 303▕         throw new UnknownOSException();
    304▕     }
    305▕ }
    306▕

      [2m+2 vendor frames [22m
  3   /Users/ahoiroman/Entwicklung/Laravel/exampleli/app/Domain/Measurement/Jobs/PingJob.php:37
      Acamposm\Ping\Ping::run()

      [2m+21 vendor frames [22m
  25  phar:/Applications/Invoker.app/Contents/Resources/invoker.phar/src/Actions/DispatchEventAction.php:25
      dispatch(Object(App\Domain\Measurement\Jobs\PingJob))
```

Reason: Key is `Darwin`, not `OSX`.