### PR TITLE
Fix Linux Parsing issue for Unreachable.

### DIFF
--- a/src/Parsers/PingParserForLinux.php
+++ b/src/Parsers/PingParserForLinux.php
@@ -95,7 +95,7 @@ final class PingParserForLinux extends PingParser
         $sequence = [];
 
         foreach ($ping as $row) {
-            if (str_contains($row, 'Unreachable')) {
+            if (str_contains($row, 'Unreachable') && !empty($row)) {
                 $data = explode(': ', str_replace(' ms', '', $row));
                 $items = explode(' ', $data[1]);
 


### PR DESCRIPTION
The row is empty in this case so doing explode is pointless. Not a real fix but stops the issue.