### PR TITLE
fix str_replace deprecation on null message

### DIFF
--- a/src/Parsers/PingParserForLinux.php
+++ b/src/Parsers/PingParserForLinux.php
@@ -48,7 +48,7 @@ final class PingParserForLinux extends PingParser
             'packets|transmitted|received|+|errors|%|packet|loss|time|ms'
         );
 
-        $row = trim(str_replace($search, null, $row));
+        $row = trim(str_replace($search, '', $row));
 
         return array_map('trim', explode(', ', $row));
     }
@@ -122,7 +122,7 @@ final class PingParserForLinux extends PingParser
             return [];
         }
 
-        $row = trim(str_replace(['ms', 'rtt'], null, $row));
+        $row = trim(str_replace(['ms', 'rtt'], '', $row));
 
         $rtt = explode(' = ', $row);
 


### PR DESCRIPTION
This pull request fixes deprecation warnings in PHP 8.2. 

```Deprecated: str_replace(): Passing null to parameter #2```